### PR TITLE
Bump galactic-senate gem to 0.2: support Redis 5.x

### DIFF
--- a/chequeo.gemspec
+++ b/chequeo.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'slack-ruby-client', '>= 0.9.0'
   spec.add_runtime_dependency 'fugit', '>= 1.1.5'
   spec.add_runtime_dependency 'concurrent-ruby', ">= 1.0"
-  spec.add_runtime_dependency 'galactic-senate', '~> 0.1'
+  spec.add_runtime_dependency 'galactic-senate', '~> 0.2'
   spec.add_runtime_dependency 'oj', '>= 3.6', '< 4'
   spec.add_runtime_dependency 'redis', '>= 4.0'
 


### PR DESCRIPTION
To be able to use Redis 5.x, it is necessary to update galactic-senate gem to 0.2.